### PR TITLE
Disable postgres restart.

### DIFF
--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -90,16 +90,6 @@ execute "add_permissions" do
   action :nothing
 end
 
-# TODO: Not 100% sure exactly why this should be necessary.  The
-# service is available *within* the VM, but not from *outside* until
-# it is restarted (?!)
-#
-# I have been working through several VirtualBox networking issues
-# lately, though, so that may have something to do with it.
-service "postgresql" do
-  action :restart
-end
-
 ################################################################################
 # TODO:
 #


### PR DESCRIPTION
It was set in place to address issues with VirtualBox. However,
the restart causes errors and crashes in the service.
