### PR TITLE
Set revision to deploy to 1.1.0.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@ default['app_name'] = "oc_bifrost"
 
 
 # The Git commit / tag / branch you want to check out and build from
-default['oc_bifrost']['revision'] = "master"
+default['oc_bifrost']['revision'] = "1.1.0"
 
 default['oc-authz-pedant']['revision'] = "master"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cm@opscode.com"
 license          "All rights reserved"
 description      "Installs/Configures oc_bifrost, the Opscode Authorization API"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.3"
+version          "0.2.4"
 
 recipe "opscode-bifrost", "Installs Erlang and rebar (for now)"
 recipe "database", "Creates the bifrost database, schema, and users"


### PR DESCRIPTION
Got trolled by git telling me 1.0.0 tag was created 25 days ago. So I created 1.1.0... but 25 days ago is the date of the last commit, not when the tag was created... Oh well!
