### PR TITLE
Qualify searches with a node's environment.

### DIFF
--- a/recipes/gdash.rb
+++ b/recipes/gdash.rb
@@ -353,7 +353,7 @@ end
 ################################
 
 # Machine-based Graphs
-bifrost_hosts = partial_search(:node, "role:opscode-bifrost",
+bifrost_hosts = partial_search(:node, "chef_environment:#{node.chef_environment} AND role:opscode-bifrost",
                                {"hostname" => ["hostname"]})
 
 # Our Munin clients have different hostnames in preprod (EC2)

--- a/recipes/ohc-svc.rb
+++ b/recipes/ohc-svc.rb
@@ -23,7 +23,7 @@ elsif vips["bifrost_pgsql_ip"]
   vips["bifrost_pgsql_ip"]
 else
   Chef::Log.info("Using role search for #{app} DB host")
-  search(:node, "role:bifrost-pgsql")[0].ipaddress
+  search(:node, "chef_environment:#{node.chef_environment} AND role:bifrost-pgsql")[0].ipaddress
 end
 
 # Superuser ID is in the environments data bag


### PR DESCRIPTION
See https://tickets.corp.opscode.com/browse/PROD-358 ("qualify search
queries in recipes by chef_environment") and
https://tickets.corp.opscode.com/browse/PROD-272 ("migrate all systems
in same set of environments to a single opsmaster organization") for
background.
