### PR TITLE
OPS-133 Retrieve AWS secrets with Chef Vault

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -29,3 +29,7 @@ depends "git" # for fetch_code.rb
 depends "perl"
 depends "python"
 depends "sqitch"
+
+# we manage secrets with chef-vault, use the version that supports
+# dev_mode for fallback purposes.
+depends "chef-vault", "~> 1.0.4"

--- a/recipes/api_server.rb
+++ b/recipes/api_server.rb
@@ -35,15 +35,18 @@ sys_config = {
   :estatsd_port         => node['stats_hero']['estatsd_port']
 }
 
+# AWS keys for deployment
+artifact_aws = chef_vault_item('aws', 'aws-preprod_opscode-ci-ro')['data']
+
 opscode_erlang_otp_service app_name do
   action :deploy
   app_environment node.chef_environment
   revision node[app_name]['revision']
   source node[app_name]['source']
   aws_bucket node[app_name]['aws_bucket']
-  aws_access_key_id node[app_name]['aws_access_key_id']
+  aws_access_key_id artifact_aws['aws_access_key_id']
   development_mode node[app_name]['development_mode']
-  aws_secret_access_key node[app_name]['aws_secret_access_key']
+  aws_secret_access_key artifact_aws['aws_secret_access_key']
   root_dir node[app_name]['srv_root']
   estatsd_host node[app_name]['estatsd_host']
   hipchat_key node[app_name]['hipchat_key']

--- a/recipes/ohc-svc.rb
+++ b/recipes/ohc-svc.rb
@@ -38,10 +38,6 @@ node.default[app]['database']['users']['read_only']['password'] = secrets[app]['
 # Hipchat key
 node.default[app]['hipchat_key'] = data_bag_item("environments", node.chef_environment)["hipchat_key"]
 
-# AWS keys for deployment
-artifact_aws = data_bag_item("aws", "rs-preprod")
-node.default[app]['aws_access_key_id'] = artifact_aws['aws_access_key_id']
-node.default[app]['aws_secret_access_key'] = artifact_aws['aws_secret_access_key']
 node.default[app]['aws_bucket'] = 'opscode-ci'
 
 include_recipe "opscode-bifrost::api_server"


### PR DESCRIPTION
This is initiated from [OPS-133](https://tickets.corp.opscode.com/browse/OPS-133). Please review, @igarrison @paulmooring @sdelano @mmzyk @marcparadise @christophermaier 

In Hosted, we deploy artifacts from the preprod `opscode-ci` S3 bucket. This recipe was previously using the "master" credentials via a data bag item. This data bag item should be removed, so we aren't storing plaintext master credentials, and instead use IAM user permissions that only have access to read the `opscode-ci` bucket.

To summarize the changes:
- depend on the `chef-vault` cookbook of a version that includes support for `dev_mode` fallback.
- don't store the credentials in attributes - this makes them searchable across the entire Chef Server.
- move the item loading to chef_vault and do it in the api_server recipe, as the attribute storage was removed
