### PR TITLE
Relax chef-vault version to minor , not patch

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -32,4 +32,4 @@ depends "sqitch"
 
 # we manage secrets with chef-vault, use the version that supports
 # dev_mode for fallback purposes.
-depends "chef-vault", "~> 1.0.4"
+depends "chef-vault", "~> 1.0"


### PR DESCRIPTION
In 620b1a32, chef-vault was added for AWS secrets. The version constraint was
used to ensure that the `dev_mode` fallback capability of the chef-vault
cookbook was available.

The pessimistic operator against the patch version is too restrictive. We
should be able to use a cookbook that we maintain (chef-vault) of later minor
versions without issue, but we will want to avoid major version updates.
