### PR TITLE
Set release_type to relx for 12.1.0+ oc_bifrost versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cm@opscode.com"
 license          "All rights reserved"
 description      "Installs/Configures oc_bifrost, the Opscode Authorization API"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.5.2"
+version          "0.6.0"
 
 recipe "api_server", "Installs the Bifrost service"
 recipe "database", "Creates the bifrost database, schema, and users"

--- a/recipes/api_server.rb
+++ b/recipes/api_server.rb
@@ -58,4 +58,5 @@ opscode_erlang_otp_service app_name do
   owner node[app_name]['owner']
   group node[app_name]['group']
   sys_config sys_config
+  release_type :relx
 end


### PR DESCRIPTION
Requires opscode-erlang 0.2.0 or greater